### PR TITLE
TalkSlotSerializer returns private resources for orga token

### DIFF
--- a/src/pretalx/api/views/schedule.py
+++ b/src/pretalx/api/views/schedule.py
@@ -329,6 +329,13 @@ class TalkSlotViewSet(
 
         return queryset
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if not self.event:
+            return context
+        context["public_resources"] = not self.is_orga
+        return context
+
     @action(detail=True, methods=["get"])
     def ical(self, request, event, pk=None):
         """Export a single talk slot as an iCalendar file."""

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -981,33 +981,29 @@ class Submission(GenerateCode, PretalxModel):
     @cached_property
     def active_resources(self):
         return self.resources.filter(
-            models.Q(
-                models.Q(  # either the resource exists
-                    ~models.Q(resource="")
-                    & models.Q(resource__isnull=False)
-                    & ~models.Q(resource="None")
-                )
-                | models.Q(  # or the link exists
-                    models.Q(link__isnull=False) & ~models.Q(link="")
-                )
+            (  # either the resource exists
+                ~models.Q(resource="")
+                & models.Q(resource__isnull=False)
+                & ~models.Q(resource="None")
             )
-            & models.Q(is_public=True)
+            | (  # or the link exists
+                models.Q(link__isnull=False) & ~models.Q(link="")
+            ),
+            is_public=True,
         ).order_by("link")
 
     @cached_property
     def private_resources(self):
         return self.resources.filter(
-            models.Q(
-                models.Q(  # either the resource exists
-                    ~models.Q(resource="")
-                    & models.Q(resource__isnull=False)
-                    & ~models.Q(resource="None")
-                )
-                | models.Q(  # or the link exists
-                    models.Q(link__isnull=False) & ~models.Q(link="")
-                )
+            (  # either the resource exists
+                ~models.Q(resource="")
+                & models.Q(resource__isnull=False)
+                & ~models.Q(resource="None")
             )
-            & models.Q(is_public=False)
+            | (  # or the link exists
+                models.Q(link__isnull=False) & ~models.Q(link="")
+            ),
+            is_public=False,
         ).order_by("link")
 
     @property


### PR DESCRIPTION
This is small improvement that ensures TalkSlotSerializer returns private resources when the access token has orga permissions.